### PR TITLE
bump astro and deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
-    "@astrojs/sitemap": "^3.4.0",
+    "@astrojs/sitemap": "^3.5.0",
     "@fontsource-variable/inter": "^5.2.5",
     "@fontsource/inter": "^5.2.5",
     "@resvg/resvg-js": "^2.6.2",
@@ -27,8 +27,8 @@
     "satori-html": "^0.3.2"
   },
   "dependencies": {
-    "@astrojs/mdx": "^4.2.6",
-    "@astrojs/react": "^4.2.7",
+    "@astrojs/mdx": "^4.3.4",
+    "@astrojs/react": "4.3.0",
     "@iconify-json/cib": "^1.2.2",
     "@iconify-json/mdi": "^1.2.3",
     "@iconify-json/simple-icons": "^1.2.32",
@@ -36,7 +36,7 @@
     "@tailwindcss/vite": "^4.1.4",
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",
-    "astro": "^5.7.13",
+    "astro": "^5.13.2",
     "astro-compressor": "^1.0.0",
     "astro-expressive-code": "^0.40.2",
     "astro-icon": "^1.1.5",


### PR DESCRIPTION
This pull request updates several Astro-related dependencies in the `package.json` file to their latest versions. These changes help ensure compatibility, access to new features, and security improvements.

Dependency updates:

* Upgraded `@astrojs/sitemap` from version 3.4.0 to 3.5.0.
* Upgraded `@astrojs/mdx` from version 4.2.6 to 4.3.4.
* Upgraded `@astrojs/react` from version 4.2.7 to 4.3.0.
* Upgraded `astro` from version 5.7.13 to 5.13.2.