### PR TITLE
🧹 Fix memory leak: Accumulated Event Listeners on matchMedia

### DIFF
--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -164,24 +164,27 @@ const canonicalURL = new URL(Astro.url).href;
         updateThemeButtons();
       });
 
-      if (window["themeMediaQueryList"] && window["themeChangeListener"]) {
-        window["themeMediaQueryList"].removeEventListener(
-          "change",
-          window["themeChangeListener"]
+      if (window.themeMediaQueryList) {
+        if (window.themeChangeListener) {
+          window.themeMediaQueryList.removeEventListener(
+            "change",
+            window.themeChangeListener
+          );
+        }
+      } else {
+        window.themeMediaQueryList = window.matchMedia(
+          "(prefers-color-scheme: dark)"
         );
       }
 
-      window["themeMediaQueryList"] = window.matchMedia(
-        "(prefers-color-scheme: dark)"
-      );
-      window["themeChangeListener"] = (event) => {
+      window.themeChangeListener = (event) => {
         if (localStorage.theme === "system") {
           toggleTheme(event.matches);
         }
       };
-      window["themeMediaQueryList"].addEventListener(
+      window.themeMediaQueryList.addEventListener(
         "change",
-        window["themeChangeListener"]
+        window.themeChangeListener
       );
     }
 

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -164,13 +164,25 @@ const canonicalURL = new URL(Astro.url).href;
         updateThemeButtons();
       });
 
-      window
-        .matchMedia("(prefers-color-scheme: dark)")
-        .addEventListener("change", (event) => {
-          if (localStorage.theme === "system") {
-            toggleTheme(event.matches);
-          }
-        });
+      if (window["themeMediaQueryList"] && window["themeChangeListener"]) {
+        window["themeMediaQueryList"].removeEventListener(
+          "change",
+          window["themeChangeListener"]
+        );
+      }
+
+      window["themeMediaQueryList"] = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      );
+      window["themeChangeListener"] = (event) => {
+        if (localStorage.theme === "system") {
+          toggleTheme(event.matches);
+        }
+      };
+      window["themeMediaQueryList"].addEventListener(
+        "change",
+        window["themeChangeListener"]
+      );
     }
 
     function updateThemeButtons() {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+  interface Window {
+    themeMediaQueryList?: MediaQueryList;
+    themeChangeListener?: (event: MediaQueryListEvent) => void;
+  }
+}


### PR DESCRIPTION
This PR fixes a memory leak in `src/layouts/AppLayout.astro` caused by the accumulation of event listeners on `window.matchMedia` during client-side navigation (View Transitions).

**Changes:**
- Refactored the `init()` function to check for an existing `themeChangeListener` on the window object.
- If a listener exists, it is removed from the `themeMediaQueryList` before creating a new one.
- The `MediaQueryList` object and the listener function are stored on `window` (using bracket notation to bypass TS checks) to persist across navigations and ensure proper cleanup.

**Verification:**
- Verified that `window.themeChangeListener` and `window.themeMediaQueryList` are correctly set and accessible after page load using a Playwright script.
- Confirmed that the application renders correctly without errors.
- Confirmed that `astro check` passes without warnings related to the change.

---
*PR created automatically by Jules for task [7117462635783739413](https://jules.google.com/task/7117462635783739413) started by @ItsHarta*