### PR TITLE
🎨 Palette: Add aria-label and focus-visible to icon-only social links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-11-20 - Accessible Icon-Only Links in Dual Themes
+**Learning:** Icon-only links (e.g., social links containing just an `<Icon>`) suffer from missing accessible names for screen readers and redundant `title` readouts if the child icon still has its `title` attribute. They also lack clear keyboard focus indicators out-of-the-box, especially problematic in dual-theme setups where focus rings may clash with backgrounds.
+**Action:** When creating icon-only links, add a descriptive `aria-label` to the parent `<a>` element, remove any nested `title` attributes on SVG/Icon components to prevent duplicate announcements, and implement explicit `focus-visible` utility classes with correct background-aware `ring-offset` classes (e.g., `focus-visible:ring-offset-zinc-100 dark:focus-visible:ring-offset-zinc-900`) to guarantee clear visual focus states in both light and dark modes.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -46,60 +46,65 @@ import { author } from "@data/socials";
         <a
           href="https://github.com/ItsHarta"
           title="GitHub"
+          aria-label="GitHub profile"
           target="_blank"
           rel="noopener noreferrer"
+          class="focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-100 dark:focus-visible:ring-offset-zinc-900 rounded-sm focus-visible:outline-none"
         >
           <Icon
             name="mdi:github"
             class="text-3xl dark:text-zinc-300 dark:hover:text-zinc-300/75 text-zinc-700 hover:text-zinc-700/75"
-            title="GitHub"
           />
         </a>
         <a
           href="https://linkedin.com/in/angkasa-harta"
           title="LinkedIn"
+          aria-label="LinkedIn profile"
           target="_blank"
           rel="noopener noreferrer"
+          class="focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-100 dark:focus-visible:ring-offset-zinc-900 rounded-sm focus-visible:outline-none"
         >
           <Icon
             name="mdi:linkedin"
             class="text-3xl dark:text-zinc-300 dark:hover:text-zinc-300/75 text-zinc-700 hover:text-zinc-700/75"
-            title="LinkedIn"
           />
         </a>
         <a
           href="https://discordapp.com/users/383910339777003533"
           title="Discord"
+          aria-label="Discord profile"
           target="_blank"
           rel="noopener noreferrer"
+          class="focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-100 dark:focus-visible:ring-offset-zinc-900 rounded-sm focus-visible:outline-none"
         >
           <Icon
             name="mdi:discord"
             class="text-3xl dark:text-zinc-300 dark:hover:text-zinc-300/75 text-zinc-700 hover:text-zinc-700/75"
-            title="Discord"
           />
         </a>
         <a
           href="https://wa.me/+6281905310000"
           title="Whatsapp"
+          aria-label="WhatsApp contact"
           target="_blank"
           rel="noopener noreferrer"
+          class="focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-100 dark:focus-visible:ring-offset-zinc-900 rounded-sm focus-visible:outline-none"
         >
           <Icon
             name="mdi:whatsapp"
             class="text-3xl dark:text-zinc-300 dark:hover:text-zinc-300/75 text-zinc-700 hover:text-zinc-700/75"
-            title="Whatsapp"
           />
         </a>
         <a
           href="mailto:harta.angkasa@asthene.com"
           title="Email"
+          aria-label="Send email"
           rel="noopener noreferrer"
+          class="focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-100 dark:focus-visible:ring-offset-zinc-900 rounded-sm focus-visible:outline-none"
         >
           <Icon
             name="mdi:gmail"
             class="text-3xl dark:text-zinc-300 dark:hover:text-zinc-300/75 text-zinc-700 hover:text-zinc-700/75"
-            title="Email"
           />
         </a>
       </div>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label`s to the icon-only social media links on the homepage, removed their redundant `title` attributes, and implemented explicit `focus-visible` styling. Also recorded the UX learning in `.jules/palette.md`.

🎯 **Why:** Icon-only links lack accessible text for screen readers, leading to poor usability. The redundant `title` attribute inside the `<Icon>` can also cause double announcements. Additionally, native browser focus rings are often insufficient or clash with dark/light themes, making keyboard navigation difficult.

♿ **Accessibility:**
- Improved screen reader compatibility via explicit `aria-label` names.
- Prevented double read-outs by removing the SVG `title`.
- Enhanced keyboard accessibility with theme-aware `focus-visible` utility classes using `ring-offset`.

---
*PR created automatically by Jules for task [6007496078072672298](https://jules.google.com/task/6007496078072672298) started by @ItsHarta*